### PR TITLE
Fix Map1 in Cercana.js rendering bug

### DIFF
--- a/src/components/Main/Cercana/Cercana.jsx
+++ b/src/components/Main/Cercana/Cercana.jsx
@@ -6,8 +6,11 @@ import LocationSpinner from "../../LocationSpinner/LocationSpinner";
 import "./Cercana.css";
 
 const Cercana = () => {
-  const { gasolinerasList } = useContext(GasolinerasListContext);
   const { ubicacionUsuario } = useContext(UserUbicationContext);
+  const { status } = useContext(UserUbicationContext);
+  const { gasolinerasList } = useContext(GasolinerasListContext);
+
+
 
   return (
     <>
@@ -49,13 +52,15 @@ const Cercana = () => {
                 </tr>
                 <tr>
                   <td className="tDetailsblue">Distancia:</td>
-                  <td>{gasolinerasList[1].distancia} Km</td>
+                  <td>{gasolinerasList[0].distancia} Km</td>
                 </tr>
               </tbody>
             </table>
           </section>
           <section className="mapasSection">
-            <Mapas />
+            {status == true ?
+              <Mapas /> : 
+              <p>Espera un momento, por favor...</p>}
           </section>
         </>
       )}

--- a/src/components/Main/Cercana/MapasCercana/Map1/Map1.jsx
+++ b/src/components/Main/Cercana/MapasCercana/Map1/Map1.jsx
@@ -17,6 +17,7 @@ const Map1 = () => {
   });
 
   return (
+    <>
     <MapContainer center={[gasolinerasList[0].Latitud, gasolinerasList[0]["Longitud (WGS84)"]]} zoom={15} style={{ height: '400px', width: '100%' }}>
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -29,6 +30,7 @@ const Map1 = () => {
       </Marker>
 
     </MapContainer>
+    </>
   );
 };
 

--- a/src/components/Main/Cercana/MapasCercana/Map2/Map2.jsx
+++ b/src/components/Main/Cercana/MapasCercana/Map2/Map2.jsx
@@ -14,9 +14,9 @@ const Map2 = () => {
   delete L.Icon.Default.prototype._getIconUrl;
 
   L.Icon.Default.mergeOptions({
-    iconRetinaUrl: '/assets/images/marker-icon-2x.png',
-    iconUrl: '/assets/images/marker-icon.png',
-    shadowUrl: '/assets/images/marker-shadow.png',
+    iconRetinaUrl: '/assets/img/marker-icon-2x.png',
+    iconUrl: '/assets/img/marker-icon.png',
+    shadowUrl: '/assets/img/marker-shadow.png',
   });
 
   const customMarkerIcon = new L.Icon({

--- a/src/components/Main/Cercana/MapasCercana/Mapas.jsx
+++ b/src/components/Main/Cercana/MapasCercana/Mapas.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { MapContainer, TileLayer, Marker } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import Map1 from './Map1'; // Importa el componente del mapa con pin
@@ -12,23 +12,23 @@ const MapaConAmbos = () => {
   };
 
   return (
-    <div>
-      <button onClick={toggleMapa}>
-        {mostrarMap1 ? "Cómo Llegar" : "Volver"}
-      </button>
+        <div>
+          <button onClick={toggleMapa}>
+            {mostrarMap1 ? "Cómo Llegar" : "Volver"}
+          </button>
 
-      <MapContainer center={[0, 0]} zoom={12} style={{ height: '400px', width: '100%' , maxWidth: "620px"}}>
-        <TileLayer
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
+          <MapContainer center={[0, 0]} zoom={12} style={{ height: '400px', width: '100%' , maxWidth: "620px"}}>
+            <TileLayer
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
 
-        {mostrarMap1 ? (
-          <Map1  />
-        ) : (
-          <Map2 />
-        )}
-      </MapContainer>
-    </div>
+            {mostrarMap1 ? (
+              <Map1  />
+            ) : (
+              <Map2 />
+            )}
+          </MapContainer>
+        </div>
   );
 };
 


### PR DESCRIPTION
Ensure the nearest gas station map only renders after user location permissions are granted and the gas station list is sorted by distance

This commit addresses a bug where the map component for displaying the nearest gas station was rendering prematurely. Now, the map only renders after the user has granted location permissions and the list of gas stations has been successfully sorted by proximity to the provided location. This ensures a more accurate and user-friendly experience.